### PR TITLE
uprobe支持没有名字的so库

### DIFF
--- a/user/config/config_module.go
+++ b/user/config/config_module.go
@@ -297,6 +297,18 @@ func (this *StackUprobeConfig) Parse_HookPoint(configs []string) (err error) {
                     hook_point.PointArgs = append(hook_point.PointArgs, point_arg)
                 }
             }
+            if strings.Contains(this.LibPath, "!") {
+				libStr := strings.Split(this.LibPath, "!")
+				libExtraInfo := libStr[1]
+				libExtraOffset := strings.Split(libExtraInfo, "@")[1]
+
+				libZipOffet, err := strconv.ParseUint(strings.TrimPrefix(libExtraOffset, "0x"), 16, 64)
+				if err != nil {
+					return errors.New(fmt.Sprintf("parse for %s failed, libExtraOffset:%s err:%v", config_str, libExtraOffset, err))
+				}
+				// hook_point.LibPath = libStr[0]
+				hook_point.Offset = libZipOffet + hook_point.Offset
+			}
             this.Points = append(this.Points, hook_point)
         } else {
             return errors.New(fmt.Sprintf("parse for %s failed", config_str))

--- a/user/util/helper.go
+++ b/user/util/helper.go
@@ -179,6 +179,9 @@ func FindLib(library string, search_paths []string) (string, error) {
 	}
 	// 以 / 开头的认为是完整路径 否则在提供的路径中查找
 	if strings.HasPrefix(library, "/") {
+		if strings.Contains(library, "!") {
+			return library, nil
+		}
 		_, err := os.Stat(library)
 		if err != nil {
 			// 出现异常 提示对应的错误信息


### PR DESCRIPTION
有的app的so库不出现在maps里，需要对cilium/ebpf做些修改，然后通过so在apk文件中的偏移来激活uprobe。