### PR TITLE
support dump base64 from buf

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -665,6 +665,7 @@ func init() {
     rootCmd.PersistentFlags().StringVar(&gconfig.RegName, "reg", "", "get the offset of reg")
     rootCmd.PersistentFlags().BoolVarP(&gconfig.DumpRet, "dumpret", "", false, "dump ret offset for symbol")
     rootCmd.PersistentFlags().BoolVarP(&gconfig.DumpHex, "dumphex", "", false, "dump buffer as hex")
+    rootCmd.PersistentFlags().BoolVarP(&gconfig.DumpBase64, "dumpbase64", "", false, "dump buffer as base64")
     rootCmd.PersistentFlags().BoolVarP(&gconfig.ShowPC, "showpc", "", false, "show origin pc register value")
     rootCmd.PersistentFlags().BoolVarP(&gconfig.ShowTime, "showtime", "", false, "show event boot time info")
     rootCmd.PersistentFlags().BoolVarP(&gconfig.ShowUid, "showuid", "", false, "show process uid info")

--- a/src/common/buffer.h
+++ b/src/common/buffer.h
@@ -197,7 +197,7 @@ static __always_inline int save_str_to_buf(event_data_t *event, void *ptr, u8 in
 static __always_inline int save_utf16_to_buf(event_data_t *event, void *ptr, u8 index)
 {
     // UTF16 最大字节数（必须是偶数）
-    int max_bytes = 512;
+    int max_bytes = MAX_STRING_SIZE;
     // 直接调用 save_bytes_to_buf
     return save_bytes_to_buf(event, ptr, max_bytes, index);
 }

--- a/src/common/buffer.h
+++ b/src/common/buffer.h
@@ -197,7 +197,7 @@ static __always_inline int save_str_to_buf(event_data_t *event, void *ptr, u8 in
 static __always_inline int save_utf16_to_buf(event_data_t *event, void *ptr, u8 index)
 {
     // UTF16 最大字节数（必须是偶数）
-    int max_bytes = MAX_STRING_SIZE;
+    int max_bytes = MAX_BUF_READ_SIZE;
     // 直接调用 save_bytes_to_buf
     return save_bytes_to_buf(event, ptr, max_bytes, index);
 }

--- a/tests/config_uprobe_test_base64.json
+++ b/tests/config_uprobe_test_base64.json
@@ -1,0 +1,18 @@
+{
+    "type": "uprobe",
+    "library": "libtest.so",
+    "points": [
+        {
+            "name": "testBytesBase64",
+            "params": [
+                {
+                    "name": "buf_bytes",
+                    "type": "buf",
+                    "reg": "x0",
+                    "size": "x1",
+                    "format": "base64"
+                }
+            ]
+        }
+    ]
+}

--- a/user/argtype/argtype_base.go
+++ b/user/argtype/argtype_base.go
@@ -587,6 +587,9 @@ func (this *ARG_BUFFER) ParseArg(ptr uint64, buf *bytes.Buffer, parse_more, fmt_
 		(this.ParseImpl).(IArgBuffer).SetArgPayload(payload)
 	}
 	if !fmt_json {
+		if this.DumpBase64 {
+			return fmt.Sprintf("0x%x%s", ptr, this.ParseImpl.HexToBase64Format())
+		}
 		if this.DumpHex {
 			return fmt.Sprintf("0x%x%s", ptr, this.ParseImpl.HexFormat(this.Color))
 		}

--- a/user/argtype/config_struct.go
+++ b/user/argtype/config_struct.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/json"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"stackplz/user/util"
@@ -50,6 +51,7 @@ type IParseStruct interface {
 	GetArgStruct() *Arg_struct
 	Format() string
 	HexFormat(bool) string
+	HexToBase64Format() string
 }
 
 // 结构体类型
@@ -115,6 +117,10 @@ func (this *Arg_buffer) HexFormat(color bool) string {
 	return "()"
 }
 
+func (this *Arg_buffer) HexToBase64Format() string {
+	return fmt.Sprintf(" (base64:%s)", base64.StdEncoding.EncodeToString(this.ArgPayload))
+}
+
 func (this *Arg_buffer) MarshalJSON() ([]byte, error) {
 	type ArgStructAlias Arg_struct
 	return json.Marshal(&struct {
@@ -140,6 +146,10 @@ func (this *Arg_string) Clone() IParseStruct {
 }
 
 func (this *Arg_string) HexFormat(color bool) string {
+	return this.Format()
+}
+
+func (this *Arg_string) HexToBase64Format() string {
 	return this.Format()
 }
 
@@ -190,6 +200,10 @@ func (this *Arg_string16) HexFormat(color bool) string {
 	return this.Format()
 }
 
+func (this *Arg_string16) HexToBase64Format() string {
+	return this.Format()
+}
+
 func (this *Arg_string16) Format() string {
 	// UTF‑16LE → UTF‑8
 	s := utf16leToUtf8(this.ArgPayload)
@@ -234,6 +248,10 @@ func (this *Arg_Sigaction) GetStruct() any {
 }
 
 func (this *Arg_Sigaction) HexFormat(color bool) string {
+	return this.Format()
+}
+
+func (this *Arg_Sigaction) HexToBase64Format() string {
 	return this.Format()
 }
 
@@ -285,6 +303,10 @@ func (this *Arg_Timespec) GetStruct() any {
 }
 
 func (this *Arg_Timespec) HexFormat(color bool) string {
+	return this.Format()
+}
+
+func (this *Arg_Timespec) HexToBase64Format() string {
 	return this.Format()
 }
 

--- a/user/argtype/iargtype.go
+++ b/user/argtype/iargtype.go
@@ -25,8 +25,10 @@ type IArgType interface {
 	GetTypeIndex() uint32
 	SetParentIndex(uint32)
 	SetDumpHex(bool)
+	SetDumpBase64(bool)
 	SetColor(bool)
 	GetDumpHex() bool
+	GetDumpBase64() bool
 	GetColor() bool
 	GetParentIndex() uint32
 	GetSize() uint32
@@ -54,6 +56,7 @@ type ArgType struct {
 	ParseCB   ParseFN
 	ParseImpl IParseStruct
 	DumpHex   bool
+	DumpBase64 bool
 	Color     bool
 }
 
@@ -77,6 +80,7 @@ func (this *ArgType) Clone() IArgType {
 	at.ParseCB = this.ParseCB
 	at.ParseImpl = this.ParseImpl
 	at.DumpHex = this.DumpHex
+	at.DumpBase64 = this.DumpBase64
 	at.Color = this.Color
 	return &at
 }
@@ -105,12 +109,20 @@ func (this *ArgType) SetDumpHex(dump_hex bool) {
 	this.DumpHex = dump_hex
 }
 
+func (this *ArgType) SetDumpBase64(dump_base64 bool) {
+	this.DumpBase64 = dump_base64
+}
+
 func (this *ArgType) SetColor(color bool) {
 	this.Color = color
 }
 
 func (this *ArgType) GetDumpHex() bool {
 	return this.DumpHex
+}
+
+func (this *ArgType) GetDumpBase64() bool {
+	return this.DumpBase64
 }
 
 func (this *ArgType) GetColor() bool {

--- a/user/config/config_file.go
+++ b/user/config/config_file.go
@@ -129,6 +129,8 @@ func (this *ParamConfig) GetPointArg(arg_index, point_type uint32) *PointArg {
 	}
 
 	switch this.Format {
+	case "base64":
+		point_arg.SetDumpBase64(true)
 	case "hex":
 		point_arg.SetHexFormat()
 	case "hexdump":

--- a/user/config/config_global.go
+++ b/user/config/config_global.go
@@ -58,6 +58,7 @@ type GlobalConfig struct {
     RegName     string
     DumpRet     bool
     DumpHex     bool
+    DumpBase64  bool
     ShowPC      bool
     ShowTime    bool
     ShowUid     bool

--- a/user/config/config_module.go
+++ b/user/config/config_module.go
@@ -27,6 +27,7 @@ type StackUprobeConfig struct {
     NonElfOffset uint64
     Points       []*UprobeArgs
     DumpHex      bool
+    DumpBase64   bool
     Color        bool
 }
 
@@ -177,6 +178,7 @@ func (this *StackUprobeConfig) ParseArgType(arg_str string, point_arg *PointArg)
             }
         }
         at.SetDumpHex(this.DumpHex)
+        at.SetDumpBase64(this.DumpBase64)
         at.SetColor(this.Color)
         point_arg.SetTypeIndex(at.GetTypeIndex())
         // 这个设定用于指示是否进一步读取和解析
@@ -264,6 +266,10 @@ func (this *StackUprobeConfig) IsEnable() bool {
 
 func (this *StackUprobeConfig) SetDumpHex(dump_hex bool) {
     this.DumpHex = dump_hex
+}
+
+func (this *StackUprobeConfig) SetDumpBase64(dump_base64 bool) {
+	this.DumpBase64 = dump_base64
 }
 
 func (this *StackUprobeConfig) SetColor(color bool) {
@@ -443,6 +449,7 @@ type SyscallConfig struct {
     SysWhitelist []uint32
     SysBlacklist []uint32
     DumpHex      bool
+    DumpBase64   bool
     Color        bool
 }
 
@@ -456,6 +463,10 @@ func (this *SyscallConfig) SetLogger(logger *log.Logger) {
 
 func (this *SyscallConfig) SetDumpHex(dump_hex bool) {
     this.DumpHex = dump_hex
+}
+
+func (this *SyscallConfig) SetDumpBase64(dump_base64 bool) {
+	this.DumpBase64 = dump_base64
 }
 
 func (this *SyscallConfig) SetColor(color bool) {
@@ -539,6 +550,7 @@ func (this *SyscallConfig) Parse_FileConfig(config *SyscallFileConfig) (err erro
             point_arg := param.GetPointArg(uint32(arg_index), point_type)
 
             point_arg.SetDumpHex(this.DumpHex)
+            point_arg.SetDumpBase64(this.DumpBase64)
             point_arg.SetColor(this.Color)
 
             a_p := point_arg.Clone()
@@ -789,6 +801,7 @@ type ModuleConfig struct {
     DumpHandle  *os.File
     FmtJson     bool
     DumpHex     bool
+    DumpBase64  bool
     ShowPC      bool
     ShowTime    bool
     ShowUid     bool
@@ -854,6 +867,7 @@ func (this *ModuleConfig) InitCommonConfig(gconfig *GlobalConfig) {
     this.FmtJson = gconfig.FmtJson
     this.RegName = gconfig.RegName
     this.DumpHex = gconfig.DumpHex
+    this.DumpBase64 = gconfig.DumpBase64
     this.ShowPC = gconfig.ShowPC
     this.ShowTime = gconfig.ShowTime
     this.ShowUid = gconfig.ShowUid
@@ -864,12 +878,14 @@ func (this *ModuleConfig) InitCommonConfig(gconfig *GlobalConfig) {
 
     this.StackUprobeConf = &StackUprobeConfig{}
     this.StackUprobeConf.SetDumpHex(this.DumpHex)
+    this.StackUprobeConf.SetDumpBase64((this.DumpBase64))
     this.StackUprobeConf.SetColor(this.Color)
 
     this.SysCallConf = &SyscallConfig{}
     this.SysCallConf.SetDebug(this.Debug)
     this.SysCallConf.SetLogger(this.logger)
     this.SysCallConf.SetDumpHex(this.DumpHex)
+    this.SysCallConf.SetDumpBase64((this.DumpBase64))
     this.SysCallConf.SetColor(this.Color)
 }
 

--- a/user/config/config_point_arg.go
+++ b/user/config/config_point_arg.go
@@ -32,6 +32,10 @@ func (this *PointArg) SetDumpHex(dump_hex bool) {
 	argtype.GetArgType(this.TypeIndex).SetDumpHex(dump_hex)
 }
 
+func (this *PointArg) SetDumpBase64(dump_base64 bool) {
+	argtype.GetArgType(this.TypeIndex).SetDumpBase64(dump_base64)
+}
+
 func (this *PointArg) SetColor(color bool) {
 	argtype.GetArgType(this.TypeIndex).SetColor(color)
 }


### PR DESCRIPTION
usage 1:
./stackplz_arm64 -n com.example.test -c tests/config_uprobe_test_base64.json 
usage 2:
./stackplz_arm64 -n com.example.test --lib libtest.so --dumpbase64 -w testBytesBase64[buf:x1]
output:
with base64 :
[13173|13173|om.example.test] testBytesBase64(buf_bytes=0x7ff8c514e8 (base64:EgA0VngREhM=)) LR:0x731f123bc8 PC:0x731f123aa4 SP:0x7ff8c51430
without base64 :
[13268|13268|om.example.test] testBytesBase64(buf_bytes=0x7ff8c514e8(\x12\x004Vx\x11\x12\x13)) LR:0x731e066bc8 PC:0x731e066aa4 SP:0x7ff8c51430